### PR TITLE
Fixed external regexp issue for empty external arrays

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,9 @@ const external = Object.keys(pkg.peerDependencies || {})
 const allExternal = external.concat(Object.keys(pkg.dependencies || {}))
 
 const makeExternalPredicate = externalArr => {
+  if (externalArr.length === 0) {
+    return () => false
+  }
   const pattern = new RegExp(`^(${externalArr.join('|')})($|/)`)
   return id => pattern.test(id)
 }


### PR DESCRIPTION
This shouldn't affect you, but it's always better to be future-proof.