### PR TITLE
Add different methodologies for controlling visibility <Hidden />

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-react": "^7.6.1",
     "jest-cli": "^22.1.4",
     "jest-serializer-html": "^5.0.0",
+    "jest-styled-components": "^5.0.1",
     "opn-cli": "^3.1.0",
     "prettier": "1.10.2",
     "prop-types": "^15.6.1",

--- a/src/components/Hidden/Hidden.js
+++ b/src/components/Hidden/Hidden.js
@@ -41,12 +41,29 @@ class Component extends React.Component {
 
 hoistNonReactStatics(Component, Base);
 
+/**
+ * Gets the css method for hiding the element based on the requested styleProp
+ * @param {'visibility' | 'opacity' | 'display'} styleProp
+ */
+const hiddenCssForStyleProp = styleProp => {
+  switch (styleProp) {
+    case "visibility":
+      return css`
+        visibility: hidden !important;
+      `;
+    case "opacity":
+      return css`
+        opacity: 0 !important;
+      `;
+    default:
+      return css`
+        display: none !important;
+      `;
+  }
+};
+
 const Hidden = styled(Component)`
-  ${props =>
-    !props.visible &&
-    css`
-      display: none !important;
-    `};
+  ${props => !props.visible && hiddenCssForStyleProp(props.styleProp)};
   ${prop("theme.Hidden")};
 `;
 
@@ -54,7 +71,8 @@ Hidden.propTypes = {
   hide: PropTypes.func,
   hideOnEsc: PropTypes.bool,
   visible: PropTypes.bool,
-  destroy: PropTypes.bool
+  destroy: PropTypes.bool,
+  styleProp: PropTypes.oneOf(["display", "visibility", "opacity"])
 };
 
 export default as("div")(Hidden);

--- a/src/components/Hidden/__tests__/Hidden-test.js
+++ b/src/components/Hidden/__tests__/Hidden-test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
+import "jest-styled-components";
 import Hidden from "../Hidden";
 
 const addEventListener = jest.spyOn(document.body, "addEventListener");
@@ -59,4 +60,31 @@ it("adds event handler when component becomes visible", () => {
   expect(addEventListener).not.toHaveBeenCalled();
   wrapper.setProps({ visible: true });
   expect(addEventListener).toHaveBeenCalledTimes(1);
+});
+
+describe("visibility methodologies", () => {
+  describe("destroy", () => {
+    it("removes the element when visible is false", () => {
+      const wrapper = mount(<Hidden visible={false} destroy />);
+      expect(wrapper.html()).toBe(null);
+    });
+  });
+  describe("display", () => {
+    it("adds display: none", () => {
+      const wrapper = mount(<Hidden visible={false} />);
+      expect(wrapper).toHaveStyleRule("display", "none !important");
+    });
+  });
+  describe("visibility", () => {
+    it("adds visibility: hidden", () => {
+      const wrapper = mount(<Hidden visible={false} styleProp="visibility" />);
+      expect(wrapper).toHaveStyleRule("visibility", "hidden !important");
+    });
+  });
+  describe("opacity", () => {
+    it("adds opacity: 0", () => {
+      const wrapper = mount(<Hidden visible={false} styleProp="opacity" />);
+      expect(wrapper).toHaveStyleRule("opacity", "0 !important");
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2517,6 +2517,15 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
+css@^2.2.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.3.tgz#f861f4ba61e79bedc962aa548e5780fd95cbc6be"
+  dependencies:
+    inherits "^2.0.1"
+    source-map "^0.1.38"
+    source-map-resolve "^0.5.1"
+    urix "^0.1.0"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -5204,6 +5213,12 @@ jest-snapshot@^22.4.0:
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     pretty-format "^22.4.3"
+
+jest-styled-components@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-5.0.1.tgz#386c5a161a0f5e783444d624bfc18c6d228d1277"
+  dependencies:
+    css "^2.2.1"
 
 jest-util@^22.4.1, jest-util@^22.4.3:
   version "22.4.3"
@@ -8353,7 +8368,7 @@ source-map-loader@^0.2.3:
     loader-utils "~0.2.2"
     source-map "~0.6.1"
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   dependencies:
@@ -8383,6 +8398,12 @@ source-map-url@^0.4.0:
 source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.1.38:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  dependencies:
+    amdefine ">=0.0.4"
 
 source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
closes #57 

- Adds additional implementations for controlling visibility of `<Hidden />` components. 
- Adds [jest-styled-components](https://github.com/styled-components/jest-styled-components) library to dev dependencies. This will allow making assertions about a component's style attributes.

## TODO

- [ ] Update docs