### PR TITLE
Add missing themable components

### DIFF
--- a/src/components/Overlay/OverlayContainer.js
+++ b/src/components/Overlay/OverlayContainer.js
@@ -1,0 +1,5 @@
+import HiddenContainer from "../Hidden/HiddenContainer";
+
+const OverlayContainer = HiddenContainer;
+
+export default OverlayContainer;

--- a/src/components/Overlay/OverlayHide.js
+++ b/src/components/Overlay/OverlayHide.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import HiddenHide from "../Hidden/HiddenHide";
+
+const OverlayHide = styled(HiddenHide)`
+  ${prop("theme.OverlayHide")};
+`;
+
+export default OverlayHide;

--- a/src/components/Overlay/OverlayShow.js
+++ b/src/components/Overlay/OverlayShow.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import HiddenShow from "../Hidden/HiddenShow";
+
+const OverlayShow = styled(HiddenShow)`
+  ${prop("theme.OverlayShow")};
+`;
+
+export default OverlayShow;

--- a/src/components/Overlay/OverlayToggle.js
+++ b/src/components/Overlay/OverlayToggle.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import HiddenToggle from "../Hidden/HiddenToggle";
+
+const OverlayToggle = styled(HiddenToggle)`
+  ${prop("theme.OverlayToggle")};
+`;
+
+export default OverlayToggle;

--- a/src/components/Overlay/index.js
+++ b/src/components/Overlay/index.js
@@ -1,9 +1,12 @@
 import Overlay from "./Overlay";
-import Hidden from "../Hidden";
+import OverlayContainer from "./OverlayContainer";
+import OverlayToggle from "./OverlayToggle";
+import OverlayShow from "./OverlayShow";
+import OverlayHide from "./OverlayHide";
 
-Overlay.Container = Hidden.Container;
-Overlay.Toggle = Hidden.Toggle;
-Overlay.Show = Hidden.Show;
-Overlay.Hide = Hidden.Hide;
+Overlay.Container = OverlayContainer;
+Overlay.Toggle = OverlayToggle;
+Overlay.Show = OverlayShow;
+Overlay.Hide = OverlayHide;
 
 export default Overlay;

--- a/src/components/Popover/PopoverHide.js
+++ b/src/components/Popover/PopoverHide.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import HiddenHide from "../Hidden/HiddenHide";
+
+const PopoverHide = styled(HiddenHide)`
+  ${prop("theme.PopoverHide")};
+`;
+
+export default PopoverHide;

--- a/src/components/Popover/PopoverShow.js
+++ b/src/components/Popover/PopoverShow.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import HiddenShow from "../Hidden/HiddenShow";
+
+const PopoverShow = styled(HiddenShow)`
+  ${prop("theme.PopoverShow")};
+`;
+
+export default PopoverShow;

--- a/src/components/Popover/index.js
+++ b/src/components/Popover/index.js
@@ -2,12 +2,13 @@ import Popover from "./Popover";
 import PopoverArrow from "./PopoverArrow";
 import PopoverContainer from "./PopoverContainer";
 import PopoverToggle from "./PopoverToggle";
-import Hidden from "../Hidden";
+import PopoverShow from "./PopoverShow";
+import PopoverHide from "./PopoverHide";
 
 Popover.Arrow = PopoverArrow;
 Popover.Container = PopoverContainer;
 Popover.Toggle = PopoverToggle;
-Popover.Show = Hidden.Show;
-Popover.Hide = Hidden.Hide;
+Popover.Show = PopoverShow;
+Popover.Hide = PopoverHide;
 
 export default Popover;

--- a/src/components/Sidebar/SidebarContainer.js
+++ b/src/components/Sidebar/SidebarContainer.js
@@ -1,0 +1,5 @@
+import OverlayContainer from "../Overlay/OverlayContainer";
+
+const SidebarContainer = OverlayContainer;
+
+export default SidebarContainer;

--- a/src/components/Sidebar/SidebarHide.js
+++ b/src/components/Sidebar/SidebarHide.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import OverlayHide from "../Overlay/OverlayHide";
+
+const SidebarHide = styled(OverlayHide)`
+  ${prop("theme.SidebarHide")};
+`;
+
+export default SidebarHide;

--- a/src/components/Sidebar/SidebarShow.js
+++ b/src/components/Sidebar/SidebarShow.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import OverlayShow from "../Overlay/OverlayShow";
+
+const SidebarShow = styled(OverlayShow)`
+  ${prop("theme.SidebarShow")};
+`;
+
+export default SidebarShow;

--- a/src/components/Sidebar/SidebarToggle.js
+++ b/src/components/Sidebar/SidebarToggle.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import OverlayToggle from "../Overlay/OverlayToggle";
+
+const SidebarToggle = styled(OverlayToggle)`
+  ${prop("theme.SidebarToggle")};
+`;
+
+export default SidebarToggle;

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -1,9 +1,12 @@
 import Sidebar from "./Sidebar";
-import Overlay from "../Overlay";
+import SidebarContainer from "./SidebarContainer";
+import SidebarToggle from "./SidebarToggle";
+import SidebarShow from "./SidebarShow";
+import SidebarHide from "./SidebarHide";
 
-Sidebar.Container = Overlay.Container;
-Sidebar.Toggle = Overlay.Toggle;
-Sidebar.Show = Overlay.Show;
-Sidebar.Hide = Overlay.Hide;
+Sidebar.Container = SidebarContainer;
+Sidebar.Toggle = SidebarToggle;
+Sidebar.Show = SidebarShow;
+Sidebar.Hide = SidebarHide;
 
 export default Sidebar;

--- a/src/components/Step/index.js
+++ b/src/components/Step/index.js
@@ -1,16 +1,16 @@
 import Step from "./Step";
 import StepContainer from "./StepContainer";
+import StepToggle from "./StepToggle";
+import StepShow from "./StepShow";
 import StepHide from "./StepHide";
 import StepNext from "./StepNext";
 import StepPrevious from "./StepPrevious";
-import StepShow from "./StepShow";
-import StepToggle from "./StepToggle";
 
 Step.Container = StepContainer;
+Step.Toggle = StepToggle;
+Step.Show = StepShow;
 Step.Hide = StepHide;
 Step.Next = StepNext;
 Step.Previous = StepPrevious;
-Step.Show = StepShow;
-Step.Toggle = StepToggle;
 
 export default Step;

--- a/src/components/Tabs/TabsNext.js
+++ b/src/components/Tabs/TabsNext.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import StepNext from "../Step/StepNext";
+
+const TabsNext = styled(StepNext)`
+  ${prop("theme.TabsNext")};
+`;
+
+export default TabsNext;

--- a/src/components/Tabs/TabsPrevious.js
+++ b/src/components/Tabs/TabsPrevious.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { prop } from "styled-tools";
+import StepPrevious from "../Step/StepPrevious";
+
+const TabsPrevious = styled(StepPrevious)`
+  ${prop("theme.TabsPrevious")};
+`;
+
+export default TabsPrevious;

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -2,13 +2,13 @@ import Tabs from "./Tabs";
 import TabsContainer from "./TabsContainer";
 import TabsTab from "./TabsTab";
 import TabsPanel from "./TabsPanel";
-import Step from "../Step";
+import TabsNext from "./TabsNext";
+import TabsPrevious from "./TabsPrevious";
 
 Tabs.Container = TabsContainer;
 Tabs.Tab = TabsTab;
 Tabs.Panel = TabsPanel;
-Tabs.Next = Step.Next;
-Tabs.Previous = Step.Previous;
-Tabs.Select = Step.Select;
+Tabs.Next = TabsNext;
+Tabs.Previous = TabsPrevious;
 
 export default Tabs;


### PR DESCRIPTION
- [x] `OverlayHide`
- [x] `OverlayShow`
- [x] `OverlayToggle`
- [x] `PopoverHide`
- [x] `PopoverShow`
- [x] `SidebarHide`
- [x] `SidebarShow`
- [x] `SidebarToggle`
- [x] `TabsNext`
- [x] `TabsPrevious`

Before, we were just exporting the base component directly. Some components were themable while others weren't. This PR fixes that inconsistency. I'm not sure about how this impacts performance, but we can measure that later.

This is related to #89 and #95